### PR TITLE
fix: targetNode not bound with sh:and

### DIFF
--- a/packages/demo/public/docs/example/targetNode.ttl.rq
+++ b/packages/demo/public/docs/example/targetNode.ttl.rq
@@ -1,3 +1,8 @@
 PREFIX schema: <http://schema.org/>
-CONSTRUCT { <https://tbbt.tv/sheldon-cooper> schema:name ?resource2. }
-WHERE { <https://tbbt.tv/sheldon-cooper> schema:name ?resource2. }
+CONSTRUCT { ?resource1 schema:name ?resource2. }
+WHERE {
+  VALUES ?resource1 {
+    <https://tbbt.tv/sheldon-cooper>
+  }
+  ?resource1 schema:name ?resource2.
+}

--- a/packages/demo/public/docs/example/values-constant.ttl.rq
+++ b/packages/demo/public/docs/example/values-constant.ttl.rq
@@ -1,9 +1,12 @@
 PREFIX schema: <http://schema.org/>
 CONSTRUCT {
-  <https://tbbt.tv/sheldon-cooper> schema:givenName ?resource3.
-  <https://tbbt.tv/sheldon-cooper> schema:familyName ?resource5.
+  ?resource1 schema:givenName ?resource3.
+  ?resource1 schema:familyName ?resource5.
 }
 WHERE {
+  VALUES ?resource1 {
+    <https://tbbt.tv/sheldon-cooper>
+  }
   { BIND("Sheldon" AS ?resource3) }
   UNION
   { BIND("Cooper" AS ?resource5) }

--- a/packages/demo/public/docs/example/values-focus-node.ttl.rq
+++ b/packages/demo/public/docs/example/values-focus-node.ttl.rq
@@ -1,3 +1,8 @@
 PREFIX schema: <http://schema.org/>
-CONSTRUCT { <https://tbbt.tv/sheldon-cooper> schema:knows ?resource3. }
-WHERE { BIND(<https://tbbt.tv/sheldon-cooper> AS ?resource3) }
+CONSTRUCT { ?resource1 schema:knows ?resource3. }
+WHERE {
+  VALUES ?resource1 {
+    <https://tbbt.tv/sheldon-cooper>
+  }
+  BIND(?resource1 AS ?resource3)
+}

--- a/packages/shape-to-query/model/NodeShape.ts
+++ b/packages/shape-to-query/model/NodeShape.ts
@@ -1,9 +1,8 @@
 import { Variable } from 'rdf-js'
-import { isResource } from 'is-graph-pointer'
 import { sparql, SparqlTemplateResult } from '@tpluscode/sparql-builder'
 import { emptyPatterns, flatten, ShapePatterns, union } from '../lib/shapePatterns'
 import { PropertyShape } from './PropertyShape'
-import { Target, TargetNode } from './target'
+import { Target } from './target'
 import { ConstraintComponent } from './constraint/ConstraintComponent'
 import Shape, { BuildParameters } from './Shape'
 
@@ -22,22 +21,14 @@ export default class extends Shape implements NodeShape {
   }
 
   buildPatterns(arg: BuildParameters): ShapePatterns {
-    let { focusNode, variable } = arg
     let targets: ShapePatterns = emptyPatterns
     if (arg.focusNode.termType === 'Variable') {
-      targets = union(...this.targets.flatMap(target => target.buildPatterns(<any>{ focusNode, variable })))
-    }
-    if (this.targets.length === 1 && this.targets[0] instanceof TargetNode) {
-      const [target] = this.targets
-      if (isResource(target.nodes)) {
-        targets = emptyPatterns
-        focusNode = target.nodes.term
-      }
+      targets = union(...this.targets.flatMap(target => target.buildPatterns(<any>arg)))
     }
 
     let properties: ShapePatterns = emptyPatterns
     if (this.properties.length) {
-      properties = union(...this.properties.map(p => p.buildPatterns({ focusNode, variable })))
+      properties = union(...this.properties.map(p => p.buildPatterns(arg)))
     }
 
     const logical = this.buildLogicalConstraints(arg)

--- a/packages/shape-to-query/test/index.test.ts
+++ b/packages/shape-to-query/test/index.test.ts
@@ -50,28 +50,6 @@ describe('@hydrofoil/shape-to-query', () => {
           }`)
         })
       })
-
-      context('node target', () => {
-        it('single value replaces root subject', async () => {
-          // given
-          const shape = await parse`
-            <>
-              a ${sh.NodeShape} ;
-              ${sh.targetNode} ${foaf.Person} ;
-              ${sh.property} [ ${sh.path} ${foaf.name} ] ;
-            .
-          `
-
-          // when
-          const patterns = shapeToPatterns(shape, { subjectVariable: 'node' })
-          const query = SELECT.ALL.WHERE`${patterns.whereClause}`.build()
-
-          // then
-          expect(query).to.be.a.query(sparql`SELECT * WHERE {
-            ${foaf.Person} ${foaf.name} ?name .
-          }`)
-        })
-      })
     })
 
     context('property constraints', () => {
@@ -205,36 +183,6 @@ describe('@hydrofoil/shape-to-query', () => {
         // when
         const focusNode = ex.John
         const query = constructQuery(shape, { focusNode }).build()
-
-        // then
-        expect(query).to.be.a.query(sparql`CONSTRUCT {
-          ${ex.John} ${foaf.name} ?resource_0 .
-          ${ex.John} ${foaf.lastName} ?resource_1 .
-        } WHERE {
-          { ${ex.John} ${foaf.name} ?resource_0 . }
-          union
-          { ${ex.John} ${foaf.lastName} ?resource_1 . }
-        }`)
-      })
-
-      it('generates a query for a single target node', async () => {
-        // given
-        const shape = await parse`
-          <>
-            a ${sh.NodeShape} ;
-            ${sh.targetNode} ${ex.John} ;
-            ${sh.property}
-            [
-              ${sh.path} ${foaf.name} ;
-            ],
-            [
-              ${sh.path} ${foaf.lastName} ;
-            ] ; 
-          .
-        `
-
-        // when
-        const query = constructQuery(shape).build()
 
         // then
         expect(query).to.be.a.query(sparql`CONSTRUCT {


### PR DESCRIPTION
A shape with a single target did not correctly bind it with inner `sh:and`/`sh:or` shapes because the root shape replaced its root focus node with a constant term, leaving the inner shapes unbound `?resource1`