### PR TITLE
fix: calling function without meta

### DIFF
--- a/.changeset/perfect-cars-beam.md
+++ b/.changeset/perfect-cars-beam.md
@@ -1,0 +1,5 @@
+---
+"@hydrofoil/shape-to-query": patch
+---
+
+Function expression did not work for arbitrary IRI which was not explicitly annotated as `sh:Function`

--- a/packages/shape-to-query/model/nodeExpression/FunctionExpression.ts
+++ b/packages/shape-to-query/model/nodeExpression/FunctionExpression.ts
@@ -26,9 +26,7 @@ export abstract class FunctionExpression extends NodeExpressionBase {
       return false
     }
 
-    const functionPtr = vocabulary.node(first.predicate).has(rdf.type, sh.Function)
-
-    return isGraphPointer(functionPtr) && pointer.out(functionPtr).isList()
+    return pointer.out(first.predicate).isList()
   }
 
   static fromPointer(pointer: GraphPointer, createExpr: ModelFactory) {

--- a/packages/shape-to-query/test/model/nodeExpression/FunctionExpression.test.ts
+++ b/packages/shape-to-query/test/model/nodeExpression/FunctionExpression.test.ts
@@ -54,16 +54,6 @@ describe('model/nodeExpression/FunctionExpression', () => {
       expect(FunctionExpression.match(pointer)).to.be.false
     })
 
-    it('returns false when expression has multiple predicates', () => {
-      // given
-      const pointer = blankNode()
-        .addOut(dashSparql.and, blankNode())
-        .addOut(dashSparql.or, blankNode())
-
-      // when
-      expect(FunctionExpression.match(pointer)).to.be.false
-    })
-
     it('returns true when expression has a single predicate of known sh:Function', () => {
       // given
       const pointer = blankNode()
@@ -73,7 +63,16 @@ describe('model/nodeExpression/FunctionExpression', () => {
       expect(FunctionExpression.match(pointer)).to.be.true
     })
 
-    it('returns true when expression has a single predicate of known sh:Function but not a list', () => {
+    it('returns true when expression has a single predicate of an arbitrary predicate', () => {
+      // given
+      const pointer = blankNode()
+        .addList(xsd.int, blankNode())
+
+      // when
+      expect(FunctionExpression.match(pointer)).to.be.true
+    })
+
+    it('returns false when expression has a single predicate of known sh:Function but not a list', () => {
       // given
       const pointer = blankNode()
         .addOut(dashSparql.and, blankNode())
@@ -134,6 +133,19 @@ describe('model/nodeExpression/FunctionExpression', () => {
 
       // then
       expect(expr.returnType).to.deep.eq(xsd.string)
+    })
+
+    it('returns new function from arbitrary IRI', () => {
+      // given
+      const pointer = blankNode()
+        .addList(xsd.int, [])
+
+      // when
+      const expr = FunctionExpression.fromPointer(pointer, factory)
+
+      // then
+      expect(expr).to.be.instanceof(FunctionCallExpression)
+      expect(expr.symbol).to.deep.eq(xsd.int)
     })
 
     const additiveExpressions = [


### PR DESCRIPTION
A simple scenario which failed was `xsd:int()` to cast